### PR TITLE
fix: improve error handling when editing messages

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -161,19 +161,16 @@ async def start_inline_edit(index: int, request: Request):
 
 @router.post("/inline-edit/{index}", response_class=HTMLResponse)
 async def save_inline_edit(request: Request, index: int, content: str = Form(...)):
-    print("POST /inline-edit route loaded")
     history = request.session.get("history", [])
-    print(history)
     if index < 0 or index >= len(history):
-        print("POST /inline-edit route loaded6")
         return RedirectResponse("/")
-    print("POST /inline-edit route loaded4")
-    # Update message in session
+
+    # Update message in session and drop later history
     history[index]["content"] = content
-    history = history[:index + 1]
+    history = history[: index + 1]
     request.session["history"] = history
     request.session.pop("edit_index", None)
-    print("POST /inline-edit route loaded 2")
+
     db = SessionLocal()
     conversation_id = request.session["conversation_id"]
     msg_service = MessageService(db)
@@ -183,18 +180,22 @@ async def save_inline_edit(request: Request, index: int, content: str = Form(...
     msg_service.update_content(all_msgs[index].id, content)
 
     # Delete later messages
-    for m in all_msgs[index+1:]:
+    for m in all_msgs[index + 1 :]:
         msg_service.delete(m.id)
-    print("POST /inline-edit route loaded 3")
+
     # Regenerate assistant reply if editing a user message
     if history[index]["role"] == "user":
-        response = requests.post(
-            OLLAMA_URL,
-            json={"model": OLLAMA_MODEL, "messages": history, "stream": False},
-        )
-        ai_message = response.json().get("message", {}).get("content", "").strip()
-        history.append({"role": "assistant", "content": ai_message})
-        msg_service.add_message(conversation_id, "assistant", ai_message)
-        request.session["history"] = history
+        try:
+            response = requests.post(
+                OLLAMA_URL,
+                json={"model": OLLAMA_MODEL, "messages": history, "stream": False},
+            )
+            response.raise_for_status()
+            ai_message = response.json().get("message", {}).get("content", "").strip()
+            history.append({"role": "assistant", "content": ai_message})
+            msg_service.add_message(conversation_id, "assistant", ai_message)
+            request.session["history"] = history
+        except Exception as e:
+            print(f"Error regenerating assistant reply: {e}")
 
     return RedirectResponse(url=f"/resume/{conversation_id}", status_code=303)


### PR DESCRIPTION
## Summary
- handle errors during inline message edits to avoid crashes
- streamline session updates when saving edits

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6890da8b252c8320bbb87b5a86d77a84