### PR TITLE
Add user settings screen with ChatGPT token

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -8,6 +8,7 @@ class User(Base):
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True, nullable=False)
     password_hash = Column(String, nullable=False)
-    
+    gpt_token = Column(String, nullable=True)
+
     characters = relationship("Character", back_populates="creator")
     conversations = relationship("Conversation", back_populates="user")

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -3,5 +3,13 @@ from .chat import router as chat_router
 from .register import router as register_router
 from .character import router as character_router
 from .conversation import router as conversation_router
+from .settings import router as settings_router
 
-routers = [login_router, chat_router, register_router, character_router, conversation_router]
+routers = [
+    login_router,
+    chat_router,
+    register_router,
+    character_router,
+    conversation_router,
+    settings_router,
+]

--- a/routes/settings.py
+++ b/routes/settings.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from services import UserService
+from database import SessionLocal
+
+router = APIRouter()
+templates = Jinja2Templates(directory="templates")
+
+@router.get("/settings", response_class=HTMLResponse)
+async def settings_form(request: Request):
+    if not request.session.get("user_id"):
+        return RedirectResponse(url="/login", status_code=302)
+    db = SessionLocal()
+    service = UserService(db)
+    user = service.get_user_by_id(request.session["user_id"])
+    return templates.TemplateResponse("settings.html", {"request": request, "user": user, "message": None})
+
+@router.post("/settings", response_class=HTMLResponse)
+async def update_settings(request: Request, username: str = Form(...), gpt_token: str = Form(None)):
+    if not request.session.get("user_id"):
+        return RedirectResponse(url="/login", status_code=302)
+    db = SessionLocal()
+    service = UserService(db)
+    service.update_user(request.session["user_id"], username, gpt_token)
+    user = service.get_user_by_id(request.session["user_id"])
+    return templates.TemplateResponse(
+        "settings.html",
+        {"request": request, "user": user, "message": "Settings updated."},
+    )

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -8,6 +8,9 @@ class UserService:
     def get_user_by_username(self, username: str):
         return self.db.query(User).filter(User.username == username).first()
 
+    def get_user_by_id(self, user_id: int):
+        return self.db.query(User).filter(User.id == user_id).first()
+
     def create_user(self, username: str, password: str):
         hashed = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt())
         user = User(username=username, password_hash=hashed.decode('utf-8'))
@@ -18,3 +21,12 @@ class UserService:
 
     def verify_password(self, plain_password: str, hashed_password: str):
         return bcrypt.checkpw(plain_password.encode('utf-8'), hashed_password.encode('utf-8'))
+
+    def update_user(self, user_id: int, username: str, gpt_token: str | None):
+        user = self.get_user_by_id(user_id)
+        if user:
+            user.username = username
+            user.gpt_token = gpt_token
+            self.db.commit()
+            self.db.refresh(user)
+        return user

--- a/templates/characters.html
+++ b/templates/characters.html
@@ -48,6 +48,7 @@
       <ul>
         <li><a href="/characters">Characters</a></li>
         <li><a href="/conversations">Conversations</a></li>
+        <li><a href="/settings">Settings</a></li>
         <li><a href="/logout">Logout</a></li>
       </ul>
     </nav>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -11,6 +11,7 @@
       <ul>
         <li><a href="/characters">Characters</a></li>
         <li><a href="/conversations">Conversations</a></li>
+        <li><a href="/settings">Settings</a></li>
         <li><a href="/logout">Logout</a></li>
       </ul>
     </nav>

--- a/templates/conversations.html
+++ b/templates/conversations.html
@@ -57,6 +57,7 @@
       <ul>
         <li><a href="/characters">Characters</a></li>
         <li><a href="/conversations">Conversations</a></li>
+        <li><a href="/settings">Settings</a></li>
         <li><a href="/logout">Logout</a></li>
       </ul>
     </nav>

--- a/templates/newChat.html
+++ b/templates/newChat.html
@@ -72,6 +72,7 @@
       <ul>
         <li><a href="/characters">Characters</a></li>
         <li><a href="/conversations">Conversations</a></li>
+        <li><a href="/settings">Settings</a></li>
         <li><a href="/logout">Logout</a></li>
       </ul>
     </nav>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>User Settings</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <style>
+    .settings-form {
+      background-color: #1e1e1e;
+      padding: 30px;
+      border-radius: 12px;
+      width: 100%;
+      max-width: 600px;
+      display: flex;
+      flex-direction: column;
+      gap: 15px;
+    }
+
+    .settings-form input {
+      width: 100%;
+      padding: 12px;
+      font-size: 16px;
+      background-color: #2a2a2a;
+      border: none;
+      color: white;
+      border-radius: 8px;
+    }
+
+    .settings-form button {
+      margin-top: 15px;
+      padding: 12px;
+      font-size: 16px;
+      background-color: #00bcd4;
+      color: #121212;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: background-color 0.3s;
+    }
+
+    .settings-form button:hover {
+      background-color: #0097a7;
+    }
+
+    .form-label {
+      font-weight: bold;
+      margin-bottom: 4px;
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <nav class="sidebar">
+      <ul>
+        <li><a href="/characters">Characters</a></li>
+        <li><a href="/conversations">Conversations</a></li>
+        <li><a href="/settings">Settings</a></li>
+        <li><a href="/logout">Logout</a></li>
+      </ul>
+    </nav>
+    <div class="main-content">
+      <h1>⚙️ User Settings</h1>
+      {% if message %}
+        <p>{{ message }}</p>
+      {% endif %}
+      <form method="post" class="settings-form">
+        <div>
+          <label class="form-label">Username</label>
+          <input type="text" name="username" value="{{ user.username }}" required>
+        </div>
+        <div>
+          <label class="form-label">ChatGPT Token</label>
+          <input type="text" name="gpt_token" value="{{ user.gpt_token or '' }}">
+        </div>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `gpt_token` field to users and supporting service methods
- provide a settings screen for editing username and ChatGPT token
- link settings screen from sidebar menus

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890e9fd34b08320a8ece13487856fcd